### PR TITLE
Issue #SB-6863 fix: removing reduntant qstelemetry logging.

### DIFF
--- a/renderer/plugin.js
+++ b/renderer/plugin.js
@@ -123,7 +123,6 @@ org.ekstep.questionunitReorder.RendererPlugin = org.ekstep.contentrenderer.quest
       "type": "INPUT",
       "values": telemetryAnsArr
     }); // eslint-disable-line no-undef
-    QSTelemetryLogger.logEvent(QSTelemetryLogger.EVENT_TYPES.ASSESSEND, result); // eslint-disable-line no-undef
   }
 });
 //# sourceURL=ReorderingRendererPlugin.js


### PR DESCRIPTION
fix for when feedback is off then in last question the endpage show first then access event generated